### PR TITLE
Don't declare setuptools as an install dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,5 @@ setup(name='lazy',
       include_package_data=True,
       zip_safe=True,
       test_suite='lazy.tests',
-      install_requires=[
-          'setuptools',
-      ],
       use_2to3=True,
 )


### PR DESCRIPTION
It isn't, this module wouldn't even run without it, and declaring it as a dependency has negative effects on places where in fact it is not needed to do the install.
