### PR TITLE
Add the MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGES.rst
+include LICENSE
+include README.rst


### PR DESCRIPTION
Adds the MANIFEST.in with some standard files like the changelog, Readme, and license. The license, in particular, is needed to ensure that `sdist`s and other packages created from source include the license file and thus comply with the terms of the BSD 2-Clause license.