### PR TITLE
Add support for type checking

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE tox.ini *.rst
+include lazy/py.typed lazy/lazy.pyi

--- a/lazy/lazy.pyi
+++ b/lazy/lazy.pyi
@@ -1,0 +1,14 @@
+from typing import TypeVar, Callable, Type, Generic
+
+_R = TypeVar("_R")
+_C = TypeVar("_C")
+
+class lazy(Generic[_R, _C]):
+
+    def __init__(self, func: Callable[[_C], _R]) -> None: ...
+
+    def __get__(self, inst: _C, inst_cls: Type[_C]) -> _R: ...
+
+    @classmethod
+    def invalidate(cls, inst: _C, name: str) -> None: ...
+

--- a/lazy/py.typed
+++ b/lazy/py.typed
@@ -1,0 +1,1 @@
+# Marker file indicating support for type checking. See PEP 561.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='lazy',
       license='BSD-2-Clause',
       packages=find_packages(),
       include_package_data=True,
-      zip_safe=True,
+      zip_safe=False,
+      package_data={"lazy": ["py.typed", "lazy.pyi"]},
       test_suite='lazy.tests',
 )


### PR DESCRIPTION
These typing stubs should enable type checkers to infer the type of the lazy property from the return type of the annotated function.

I followed [these guidelines](https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages) on how to add stubs for existing packages.