### PR TITLE
add correct typing for the lazy attribute

### DIFF
--- a/lazy/lazy.py
+++ b/lazy/lazy.py
@@ -1,20 +1,30 @@
 """Decorator to create lazy attributes."""
-
+from __future__ import annotations
+from typing import TypeVar, Callable, Generic, overload, Union, Optional
 import functools
 
 
-class lazy(object):
+T = TypeVar('T')
+O = TypeVar('O')
+
+class lazy(Generic[T, O]):
     """lazy descriptor
 
     Used as a decorator to create lazy attributes. Lazy attributes
     are evaluated on first use.
     """
 
-    def __init__(self, func):
+    def __init__(self, func: Callable[[O], T]):
         self.__func = func
         functools.wraps(self.__func)(self)
 
-    def __get__(self, inst, inst_cls):
+    @overload
+    def __get__(self, inst: None, inst_cls) -> lazy: ...
+
+    @overload
+    def __get__(self, inst: O, inst_cls) -> T: ...
+
+    def __get__(self, inst: Optional[O], inst_cls) -> Union[lazy, T]:
         if inst is None:
             return self
 


### PR DESCRIPTION
currently the attribute decorated by lazy has type "lazy", which confuses mypy, pyright/pylance and pycharm. By adding typing, the decorated attribute is correctly recognized as the return type of the method. For testing, create a file with the lsp of your choice running:
```
from lazy import lazy
from datetime import date

class Test:
    @lazy
    def test1(self) -> int:
        print('calculating')
        return 10

    @lazy
    def test2(self) -> date:
        print('calculating date')
        return date(2010, 10, 10)

a = Test()
str(a.test1)
a.test2.strftime
```
without the patch the last two lines would each trigger an error.